### PR TITLE
Integrate content metadata API for topics, levels, and tags

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -52,6 +52,13 @@ export interface Topic {
   icon?: string
 }
 
+export interface Tag {
+  id: string
+  name: string
+  slug: string
+  description?: string
+}
+
 export interface Level {
   id: string
   name: string


### PR DESCRIPTION
## Summary
- add a Tag interface to the shared types
- introduce helpers to fetch topics, levels, and tags from the content API with graceful fallbacks to mock data
- expose a new tags service alongside updated topic and level fetchers that support optional search terms

## Testing
- npm run lint *(fails: command prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_b_68e0c71dd90c832a9e2b5fae2ce5e15a