### PR TITLE
Add content management dialogs for levels, topics, and tags

### DIFF
--- a/components/levels/level-form-dialog.tsx
+++ b/components/levels/level-form-dialog.tsx
@@ -1,0 +1,171 @@
+"use client"
+
+import { useEffect, useState } from "react"
+
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { useToast } from "@/hooks/use-toast"
+import { api } from "@/lib/api"
+import type { CreateLevelDto, Level, UpdateLevelDto } from "@/lib/types"
+
+interface LevelFormDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  level?: Level | null
+  onSuccess?: (level: Level) => void
+  nextOrder?: number
+}
+
+interface LevelFormState {
+  name: string
+  order: string
+}
+
+const defaultState: LevelFormState = {
+  name: "",
+  order: "1",
+}
+
+export function LevelFormDialog({ open, onOpenChange, level, onSuccess, nextOrder }: LevelFormDialogProps) {
+  const { toast } = useToast()
+  const [formState, setFormState] = useState<LevelFormState>(defaultState)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  useEffect(() => {
+    if (open) {
+      if (level) {
+        setFormState({
+          name: level.name,
+          order: String(level.order),
+        })
+      } else {
+        setFormState({
+          name: "",
+          order: String(nextOrder ?? 1),
+        })
+      }
+    }
+  }, [level, nextOrder, open])
+
+  const handleClose = () => {
+    if (!isSubmitting) {
+      onOpenChange(false)
+    }
+  }
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+
+    const trimmedName = formState.name.trim()
+    if (!trimmedName) {
+      toast({
+        title: "Name is required",
+        description: "Please provide a name for the level.",
+        variant: "destructive",
+      })
+      return
+    }
+
+    const parsedOrder = Number.parseInt(formState.order, 10)
+    if (Number.isNaN(parsedOrder) || parsedOrder < 1) {
+      toast({
+        title: "Order must be a positive number",
+        description: "Levels are displayed in ascending order.",
+        variant: "destructive",
+      })
+      return
+    }
+
+    try {
+      setIsSubmitting(true)
+      if (level) {
+        const payload: UpdateLevelDto = {
+          name: trimmedName,
+          order: parsedOrder,
+        }
+        const updatedLevel = await api.levels.update(level.id, payload)
+        toast({
+          title: "Level updated",
+          description: `\"${updatedLevel.name}\" has been updated successfully.`,
+        })
+        onSuccess?.(updatedLevel)
+      } else {
+        const payload: CreateLevelDto = {
+          name: trimmedName,
+          order: parsedOrder,
+        }
+        const createdLevel = await api.levels.create(payload)
+        toast({
+          title: "Level created",
+          description: `\"${createdLevel.name}\" is now available.`,
+        })
+        onSuccess?.(createdLevel)
+      }
+      onOpenChange(false)
+    } catch (error) {
+      console.error("Failed to submit level form", error)
+      toast({
+        title: level ? "Unable to update level" : "Unable to create level",
+        description: "Something went wrong while saving the level. Please try again.",
+        variant: "destructive",
+      })
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{level ? "Edit level" : "Create level"}</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-6">
+          <div className="space-y-2">
+            <Label htmlFor="level-name">
+              Level name <span className="text-destructive">*</span>
+            </Label>
+            <Input
+              id="level-name"
+              value={formState.name}
+              onChange={(event) => setFormState((state) => ({ ...state, name: event.target.value }))}
+              placeholder="e.g. Beginner"
+              required
+              autoFocus
+              disabled={isSubmitting}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="level-order">
+              Display order <span className="text-destructive">*</span>
+            </Label>
+            <Input
+              id="level-order"
+              type="number"
+              min={1}
+              value={formState.order}
+              onChange={(event) => setFormState((state) => ({ ...state, order: event.target.value }))}
+              placeholder="1"
+              required
+              disabled={isSubmitting}
+            />
+            <p className="text-xs text-muted-foreground">
+              Levels are shown from lowest to highest order.
+            </p>
+          </div>
+          <DialogFooter className="gap-2 sm:gap-3">
+            <Button type="button" variant="outline" onClick={handleClose} disabled={isSubmitting}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isSubmitting}>
+              {isSubmitting ? "Saving..." : level ? "Save changes" : "Create level"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+

--- a/components/tags/tag-form-dialog.tsx
+++ b/components/tags/tag-form-dialog.tsx
@@ -1,0 +1,221 @@
+"use client"
+
+import { useEffect, useMemo, useState } from "react"
+
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import { useToast } from "@/hooks/use-toast"
+import { api } from "@/lib/api"
+import type { CreateTagDto, Tag, UpdateTagDto } from "@/lib/types"
+
+interface TagFormDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  tag?: Tag | null
+  onSuccess?: (tag: Tag) => void
+  existingSlugs?: string[]
+}
+
+interface TagFormState {
+  name: string
+  slug: string
+  description: string
+}
+
+const defaultState: TagFormState = {
+  name: "",
+  slug: "",
+  description: "",
+}
+
+const slugify = (value: string) =>
+  value
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .replace(/[\s_-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+
+export function TagFormDialog({ open, onOpenChange, tag, onSuccess, existingSlugs = [] }: TagFormDialogProps) {
+  const { toast } = useToast()
+  const [formState, setFormState] = useState<TagFormState>(defaultState)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [isSlugEdited, setIsSlugEdited] = useState(false)
+
+  useEffect(() => {
+    if (open) {
+      if (tag) {
+        setFormState({
+          name: tag.name,
+          slug: tag.slug,
+          description: tag.description ?? "",
+        })
+        setIsSlugEdited(true)
+      } else {
+        setFormState(defaultState)
+        setIsSlugEdited(false)
+      }
+    }
+  }, [open, tag])
+
+  const normalisedExistingSlugs = useMemo(() => existingSlugs.map((slug) => slug.toLowerCase()), [existingSlugs])
+
+  const handleClose = () => {
+    if (!isSubmitting) {
+      onOpenChange(false)
+    }
+  }
+
+  const handleNameChange = (value: string) => {
+    setFormState((state) => ({
+      ...state,
+      name: value,
+      slug: isSlugEdited ? state.slug : slugify(value),
+    }))
+  }
+
+  const handleSlugChange = (value: string) => {
+    setIsSlugEdited(true)
+    setFormState((state) => ({ ...state, slug: slugify(value) }))
+  }
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+
+    const trimmedName = formState.name.trim()
+    const trimmedSlug = formState.slug.trim()
+    const normalisedSlug = trimmedSlug.toLowerCase()
+    const currentSlug = tag?.slug ? tag.slug.toLowerCase() : undefined
+
+    if (!trimmedName) {
+      toast({
+        title: "Name is required",
+        description: "Please provide a name for the tag.",
+        variant: "destructive",
+      })
+      return
+    }
+
+    if (!trimmedSlug) {
+      toast({
+        title: "Slug is required",
+        description: "Slugs help generate shareable URLs and must be unique.",
+        variant: "destructive",
+      })
+      return
+    }
+
+    const isSlugDuplicate = normalisedExistingSlugs.includes(normalisedSlug) && currentSlug !== normalisedSlug
+
+    if (isSlugDuplicate) {
+      toast({
+        title: "Slug already exists",
+        description: "Choose a different slug to avoid conflicts with other tags.",
+        variant: "destructive",
+      })
+      return
+    }
+
+    try {
+      setIsSubmitting(true)
+      const payloadBase = {
+        name: trimmedName,
+        slug: trimmedSlug,
+        description: formState.description.trim() || undefined,
+      }
+
+      if (tag) {
+        const payload: UpdateTagDto = payloadBase
+        const updatedTag = await api.tags.update(tag.id, payload)
+        toast({
+          title: "Tag updated",
+          description: `\"${updatedTag.name}\" has been updated successfully.`,
+        })
+        onSuccess?.(updatedTag)
+      } else {
+        const payload: CreateTagDto = payloadBase
+        const createdTag = await api.tags.create(payload)
+        toast({
+          title: "Tag created",
+          description: `\"${createdTag.name}\" is now available.`,
+        })
+        onSuccess?.(createdTag)
+      }
+      onOpenChange(false)
+    } catch (error) {
+      console.error("Failed to submit tag form", error)
+      toast({
+        title: tag ? "Unable to update tag" : "Unable to create tag",
+        description: "Something went wrong while saving the tag. Please try again.",
+        variant: "destructive",
+      })
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{tag ? "Edit tag" : "Create tag"}</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-6">
+          <div className="space-y-2">
+            <Label htmlFor="tag-name">
+              Tag name <span className="text-destructive">*</span>
+            </Label>
+            <Input
+              id="tag-name"
+              value={formState.name}
+              onChange={(event) => handleNameChange(event.target.value)}
+              placeholder="e.g. Certification"
+              required
+              autoFocus
+              disabled={isSubmitting}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="tag-slug">
+              URL slug <span className="text-destructive">*</span>
+            </Label>
+            <Input
+              id="tag-slug"
+              value={formState.slug}
+              onChange={(event) => handleSlugChange(event.target.value)}
+              placeholder="e.g. certification"
+              required
+              disabled={isSubmitting}
+            />
+            <p className="text-xs text-muted-foreground">
+              Slugs are used in URLs and API filters. Keep them lowercase and use hyphens between words.
+            </p>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="tag-description">Description</Label>
+            <Textarea
+              id="tag-description"
+              value={formState.description}
+              onChange={(event) => setFormState((state) => ({ ...state, description: event.target.value }))}
+              placeholder="Add context so others know when to apply this tag"
+              rows={4}
+              disabled={isSubmitting}
+            />
+          </div>
+          <DialogFooter className="gap-2 sm:gap-3">
+            <Button type="button" variant="outline" onClick={handleClose} disabled={isSubmitting}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isSubmitting}>
+              {isSubmitting ? "Saving..." : tag ? "Save changes" : "Create tag"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+

--- a/components/topics/topic-form-dialog.tsx
+++ b/components/topics/topic-form-dialog.tsx
@@ -1,0 +1,169 @@
+"use client"
+
+import { useEffect, useState } from "react"
+
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import { useToast } from "@/hooks/use-toast"
+import { api } from "@/lib/api"
+import type { CreateTopicDto, Topic, UpdateTopicDto } from "@/lib/types"
+
+interface TopicFormDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  topic?: Topic | null
+  onSuccess?: (topic: Topic) => void
+}
+
+interface TopicFormState {
+  name: string
+  description: string
+  icon: string
+}
+
+const defaultState: TopicFormState = {
+  name: "",
+  description: "",
+  icon: "",
+}
+
+export function TopicFormDialog({ open, onOpenChange, topic, onSuccess }: TopicFormDialogProps) {
+  const { toast } = useToast()
+  const [formState, setFormState] = useState<TopicFormState>(defaultState)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  useEffect(() => {
+    if (open) {
+      if (topic) {
+        setFormState({
+          name: topic.name,
+          description: topic.description ?? "",
+          icon: topic.icon ?? "",
+        })
+      } else {
+        setFormState(defaultState)
+      }
+    }
+  }, [open, topic])
+
+  const handleClose = () => {
+    if (!isSubmitting) {
+      onOpenChange(false)
+    }
+  }
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+
+    const trimmedName = formState.name.trim()
+    if (!trimmedName) {
+      toast({
+        title: "Name is required",
+        description: "Please provide a name for the topic.",
+        variant: "destructive",
+      })
+      return
+    }
+
+    try {
+      setIsSubmitting(true)
+      if (topic) {
+        const payload: UpdateTopicDto = {
+          name: trimmedName,
+          description: formState.description.trim() || undefined,
+          icon: formState.icon.trim() || undefined,
+        }
+        const updatedTopic = await api.topics.update(topic.id, payload)
+        toast({
+          title: "Topic updated",
+          description: `\"${updatedTopic.name}\" has been updated successfully.`,
+        })
+        onSuccess?.(updatedTopic)
+      } else {
+        const payload: CreateTopicDto = {
+          name: trimmedName,
+          description: formState.description.trim() || undefined,
+          icon: formState.icon.trim() || undefined,
+        }
+        const createdTopic = await api.topics.create(payload)
+        toast({
+          title: "Topic created",
+          description: `\"${createdTopic.name}\" is now available.`,
+        })
+        onSuccess?.(createdTopic)
+      }
+      onOpenChange(false)
+    } catch (error) {
+      console.error("Failed to submit topic form", error)
+      toast({
+        title: topic ? "Unable to update topic" : "Unable to create topic",
+        description: "Something went wrong while saving the topic. Please try again.",
+        variant: "destructive",
+      })
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{topic ? "Edit topic" : "Create topic"}</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-6">
+          <div className="space-y-2">
+            <Label htmlFor="topic-name">
+              Topic name <span className="text-destructive">*</span>
+            </Label>
+            <Input
+              id="topic-name"
+              value={formState.name}
+              onChange={(event) => setFormState((state) => ({ ...state, name: event.target.value }))}
+              placeholder="e.g. Programming"
+              required
+              autoFocus
+              disabled={isSubmitting}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="topic-description">Description</Label>
+            <Textarea
+              id="topic-description"
+              value={formState.description}
+              onChange={(event) => setFormState((state) => ({ ...state, description: event.target.value }))}
+              placeholder="Add a short summary to help admins understand this topic"
+              rows={4}
+              disabled={isSubmitting}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="topic-icon">Icon or emoji</Label>
+            <Input
+              id="topic-icon"
+              value={formState.icon}
+              onChange={(event) => setFormState((state) => ({ ...state, icon: event.target.value }))}
+              placeholder="Optional emoji or icon identifier"
+              disabled={isSubmitting}
+            />
+            <p className="text-xs text-muted-foreground">
+              Use an emoji (e.g. 🔬) or enter an icon identifier recognised by your design system.
+            </p>
+          </div>
+          <DialogFooter className="gap-2 sm:gap-3">
+            <Button type="button" variant="outline" onClick={handleClose} disabled={isSubmitting}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isSubmitting}>
+              {isSubmitting ? "Saving..." : topic ? "Save changes" : "Create topic"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -52,6 +52,14 @@ export interface Topic {
   icon?: string
 }
 
+export interface CreateTopicDto {
+  name: string
+  description?: string
+  icon?: string
+}
+
+export type UpdateTopicDto = Partial<CreateTopicDto>
+
 export interface Tag {
   id: string
   name: string
@@ -59,11 +67,26 @@ export interface Tag {
   description?: string
 }
 
+export interface CreateTagDto {
+  name: string
+  slug: string
+  description?: string
+}
+
+export type UpdateTagDto = Partial<CreateTagDto>
+
 export interface Level {
   id: string
   name: string
   order: number
 }
+
+export interface CreateLevelDto {
+  name: string
+  order?: number
+}
+
+export type UpdateLevelDto = Partial<CreateLevelDto>
 
 export interface Lesson {
   id: string


### PR DESCRIPTION
## Summary
- add client dialogs for creating and editing levels, topics, and tags with validation and toasts
- update the levels, topics, and tags pages to expose create buttons, row actions, and confirmation dialogs
- extend the mock API service and shared types with create/update/delete support for the content resources

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e3226f48c8832a8b689c7cf41a01a3