### PR TITLE
Use GraphQL filters for lessons CRUD

### DIFF
--- a/components/lessons/lesson-list.tsx
+++ b/components/lessons/lesson-list.tsx
@@ -1,5 +1,5 @@
 "use client"
-import { BookOpen, Plus, Search, Eye, Edit, Trash2, Globe, GlobeLock } from "lucide-react"
+import { BookOpen, Plus, Search, Eye, Edit, Trash2, Globe, GlobeLock, Loader2 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Badge } from "@/components/ui/badge"
@@ -32,6 +32,7 @@ interface LessonListProps {
   onLevelFilterChange: (levelId: string) => void
   publishedFilter: string
   onPublishedFilterChange: (filter: string) => void
+  isLoading?: boolean
 }
 
 export function LessonList({
@@ -51,6 +52,7 @@ export function LessonList({
   onLevelFilterChange,
   publishedFilter,
   onPublishedFilterChange,
+  isLoading = false,
 }: LessonListProps) {
   const getTopicName = (topicId: string) => topics.find((t) => t.id === topicId)?.name || "Unknown"
   const getLevelName = (levelId: string) => levels.find((l) => l.id === levelId)?.name || "Unknown"
@@ -126,7 +128,12 @@ export function LessonList({
         </div>
 
         <div className="divide-y divide-border">
-          {lessons.length === 0 ? (
+          {isLoading ? (
+            <div className="p-12 text-center text-muted-foreground flex flex-col items-center gap-3">
+              <Loader2 className="h-8 w-8 animate-spin" />
+              <p>Loading lessons...</p>
+            </div>
+          ) : lessons.length === 0 ? (
             <div className="p-12 text-center text-muted-foreground">
               <BookOpen className="h-12 w-12 mx-auto mb-4 opacity-50" />
               <p>No lessons found</p>

--- a/content_schema.ts
+++ b/content_schema.ts
@@ -603,6 +603,10 @@ export interface UpdateLessonVariables {
   input: UpdateLessonInput;
 }
 
+export interface DeleteLessonVariables {
+  id: string;
+}
+
 export interface PublishLessonVariables {
   id: string;
 }
@@ -798,6 +802,10 @@ export interface CreateLessonResponse {
 
 export interface UpdateLessonResponse {
   updateLesson: Lesson;
+}
+
+export interface DeleteLessonResponse {
+  deleteLesson: boolean;
 }
 
 export interface PublishLessonResponse {

--- a/lib/api/modules/lessons.ts
+++ b/lib/api/modules/lessons.ts
@@ -2,6 +2,7 @@ import type { Lesson, LessonFilters, CreateLessonDto, UpdateLessonDto } from '@/
 import { apolloClient } from '@/lib/graphql/client'
 import {
   CREATE_LESSON,
+  DELETE_LESSON,
   GET_LESSON,
   GET_LESSONS,
   PUBLISH_LESSON,
@@ -12,6 +13,8 @@ import {
   CreateLessonInput,
   CreateLessonResponse,
   CreateLessonVariables,
+  DeleteLessonResponse,
+  DeleteLessonVariables,
   GetLessonVariables,
   GetLessonsVariables,
   Lesson as GraphqlLesson,
@@ -268,7 +271,19 @@ export const lessons = {
     }
   },
 
-  delete: async () => {
-    throw new Error('Lesson deletion is not supported via GraphQL API yet')
+  delete: async (id: string): Promise<void> => {
+    try {
+      const { data } = await apolloClient.mutate<DeleteLessonResponse, DeleteLessonVariables>({
+        mutation: DELETE_LESSON,
+        variables: { id },
+      })
+
+      if (!data?.deleteLesson) {
+        throw new Error('Failed to delete lesson')
+      }
+    } catch (error) {
+      console.error('Failed to delete lesson via GraphQL:', error)
+      throw new Error('Failed to delete lesson')
+    }
   },
 }

--- a/lib/graphql/queries.ts
+++ b/lib/graphql/queries.ts
@@ -486,3 +486,9 @@ export const UNPUBLISH_LESSON = gql`
     }
   }
 `
+
+export const DELETE_LESSON = gql`
+  mutation DeleteLesson($id: ID!) {
+    deleteLesson(id: $id)
+  }
+`


### PR DESCRIPTION
## Summary
- fetch lessons with GraphQL filters that mirror the current UI controls
- load lesson metadata separately and add loading feedback in the lessons list
- implement the GraphQL deletion mutation so lesson removes succeed alongside publish/unpublish

## Testing
- not run (requires interactive ESLint configuration prompt)


------
https://chatgpt.com/codex/tasks/task_b_68e493f90e50832aa042e984ab1106d4