### PR TITLE
feat: integrate quiz GraphQL APIs

### DIFF
--- a/content_graphql.ts
+++ b/content_graphql.ts
@@ -596,3 +596,76 @@ export const DELETE_MEDIA = gql`
   }
 `;
 
+// Quizzes
+export const CREATE_QUIZ = gql`
+  mutation CreateQuiz($input: CreateQuizInput!) {
+    createQuiz(input: $input) {
+      id
+      lessonId
+      title
+      description
+      totalPoints
+      timeLimitS
+      createdAt
+      tags {
+        id
+        name
+      }
+    }
+  }
+`;
+
+export const ADD_QUIZ_QUESTION = gql`
+  mutation AddQuizQuestion($quizId: ID!, $input: CreateQuizQuestionInput!) {
+    addQuizQuestion(quizId: $quizId, input: $input) {
+      id
+      quizId
+      ord
+      type
+      prompt
+      promptMedia
+      points
+      metadata
+      options {
+        id
+        ord
+        label
+        isCorrect
+        feedback
+      }
+    }
+  }
+`;
+
+export const ADD_QUESTION_OPTION = gql`
+  mutation AddQuestionOption($questionId: ID!, $input: CreateQuestionOptionInput!) {
+    addQuestionOption(questionId: $questionId, input: $input) {
+      id
+      questionId
+      ord
+      label
+      isCorrect
+      feedback
+    }
+  }
+`;
+
+export const UPDATE_QUESTION_OPTION = gql`
+  mutation UpdateQuestionOption($id: ID!, $input: UpdateQuestionOptionInput!) {
+    updateQuestionOption(id: $id, input: $input) {
+      id
+      questionId
+      ord
+      label
+      isCorrect
+      feedback
+    }
+  }
+`;
+
+export const DELETE_QUESTION_OPTION = gql`
+  mutation DeleteQuestionOption($id: ID!) {
+    deleteQuestionOption(id: $id)
+  }
+`;
+

--- a/lib/api/modules/questions.ts
+++ b/lib/api/modules/questions.ts
@@ -1,38 +1,197 @@
-import type { Question, CreateQuestionDto } from '@/types/quiz'
-import { delay } from '@/lib/api/utils'
-import { mockQuestions, mockQuestionOptions } from '@/lib/mock-data'
+import { apolloClient } from '@/lib/graphql/client'
+import {
+  GET_QUIZ_QUESTIONS,
+  ADD_QUIZ_QUESTION,
+  ADD_QUESTION_OPTION,
+  UPDATE_QUESTION_OPTION,
+  DELETE_QUESTION_OPTION,
+} from '@/lib/graphql/queries'
+import type {
+  QuizQuestion as GraphqlQuizQuestion,
+  QuestionOption as GraphqlQuestionOption,
+  QuizQuestionsResponse,
+  GetQuizQuestionsVariables,
+  AddQuizQuestionResponse,
+  AddQuizQuestionVariables,
+  AddQuestionOptionResponse,
+  AddQuestionOptionVariables,
+  UpdateQuestionOptionResponse,
+  UpdateQuestionOptionVariables,
+  DeleteQuestionOptionResponse,
+  DeleteQuestionOptionVariables,
+} from '@/content_schema'
+import type { Question, CreateQuestionDto, QuestionOption } from '@/types/quiz'
+
+const normalizeQuestionType = (type: string): Question['type'] => {
+  const normalized = type?.toLowerCase()
+  switch (normalized) {
+    case 'multiple_choice':
+    case 'multiple-choice':
+      return 'multiple_choice'
+    case 'true_false':
+    case 'truefalse':
+    case 'true-false':
+      return 'true_false'
+    case 'fill_blank':
+    case 'fill-blank':
+    case 'fill_in_the_blank':
+      return 'fill_blank'
+    case 'audio':
+      return 'audio'
+    default:
+      return 'short_answer'
+  }
+}
+
+const mapOption = (option: GraphqlQuestionOption): QuestionOption => ({
+  id: option.id,
+  question_id: option.questionId ?? '',
+  option_text: option.label,
+  is_correct: option.isCorrect,
+  order: option.ord ?? 0,
+  feedback: option.feedback ?? undefined,
+})
+
+const mapQuestion = (question: GraphqlQuizQuestion): Question => ({
+  id: question.id,
+  quiz_id: question.quizId,
+  type: normalizeQuestionType(question.type),
+  question_text: question.prompt,
+  points: question.points ?? 0,
+  order: question.ord ?? 0,
+  prompt_media_id: question.promptMedia ?? undefined,
+  metadata: question.metadata ?? undefined,
+  options: (question.options ?? []).map(mapOption),
+})
+
+const buildQuestionInput = (data: CreateQuestionDto): AddQuizQuestionVariables['input'] => ({
+  type: data.type.replace(/-/g, '_').toUpperCase(),
+  prompt: data.question_text,
+  promptMedia: data.prompt_media_id,
+  points: data.points,
+  metadata: data.metadata,
+})
 
 export const questions = {
   getByQuizId: async (quizId: string): Promise<Question[]> => {
-    await delay()
-    return mockQuestions.filter((q) => q.quiz_id === quizId)
+    try {
+      const { data } = await apolloClient.query<QuizQuestionsResponse, GetQuizQuestionsVariables>({
+        query: GET_QUIZ_QUESTIONS,
+        variables: { quizId, page: 1, pageSize: 100 },
+        fetchPolicy: 'network-only',
+      })
+
+      const items = data?.quizQuestions?.items ?? []
+      return items.map(mapQuestion)
+    } catch (error) {
+      console.error('Failed to fetch quiz questions via GraphQL:', error)
+      throw new Error('Failed to fetch quiz questions')
+    }
   },
 
   create: async (data: CreateQuestionDto): Promise<Question> => {
-    await delay()
-    const newQuestion: Question = {
-      id: String(mockQuestions.length + 1),
-      quiz_id: data.quiz_id,
-      type: data.type,
-      question_text: data.question_text,
-      points: data.points,
-      prompt_media_id: data.prompt_media_id,
-      order: mockQuestions.filter((q) => q.quiz_id === data.quiz_id).length + 1,
-    }
-    mockQuestions.push(newQuestion)
-
-    if (data.options) {
-      data.options.forEach((opt, index) => {
-        mockQuestionOptions.push({
-          id: String(mockQuestionOptions.length + 1),
-          question_id: newQuestion.id,
-          option_text: opt.option_text,
-          is_correct: opt.is_correct,
-          order: index + 1,
-        })
+    try {
+      const { data: response } = await apolloClient.mutate<AddQuizQuestionResponse, AddQuizQuestionVariables>({
+        mutation: ADD_QUIZ_QUESTION,
+        variables: { quizId: data.quiz_id, input: buildQuestionInput(data) },
+        refetchQueries: [{ query: GET_QUIZ_QUESTIONS, variables: { quizId: data.quiz_id } }],
       })
-    }
 
-    return newQuestion
+      if (!response?.addQuizQuestion) {
+        throw new Error('Missing addQuizQuestion response')
+      }
+
+      const question = mapQuestion(response.addQuizQuestion)
+
+      if (data.options?.length) {
+        await Promise.all(
+          data.options.map((option, index) =>
+            questions.addOption(
+              response.addQuizQuestion.id,
+              {
+                ord: index + 1,
+                label: option.option_text,
+                isCorrect: option.is_correct,
+              },
+              data.quiz_id
+            )
+          )
+        )
+
+        const refreshed = await questions.getByQuizId(data.quiz_id)
+        return refreshed.find((q) => q.id === response.addQuizQuestion.id) ?? question
+      }
+
+      return question
+    } catch (error) {
+      console.error('Failed to create quiz question via GraphQL:', error)
+      throw new Error('Failed to create quiz question')
+    }
+  },
+
+  addOption: async (
+    questionId: string,
+    input: { ord: number; label: string; isCorrect: boolean; feedback?: string },
+    quizId?: string
+  ): Promise<QuestionOption> => {
+    try {
+      const { data } = await apolloClient.mutate<AddQuestionOptionResponse, AddQuestionOptionVariables>({
+        mutation: ADD_QUESTION_OPTION,
+        variables: {
+          questionId,
+          input: {
+            ord: input.ord,
+            label: input.label,
+            isCorrect: input.isCorrect,
+            feedback: input.feedback,
+          },
+        },
+        refetchQueries: quizId
+          ? [{ query: GET_QUIZ_QUESTIONS, variables: { quizId, page: 1, pageSize: 100 } }]
+          : undefined,
+      })
+
+      if (!data?.addQuestionOption) {
+        throw new Error('Missing addQuestionOption response')
+      }
+
+      return mapOption(data.addQuestionOption)
+    } catch (error) {
+      console.error('Failed to add question option via GraphQL:', error)
+      throw new Error('Failed to add question option')
+    }
+  },
+
+  updateOption: async (
+    optionId: string,
+    input: { label?: string; isCorrect?: boolean; feedback?: string }
+  ): Promise<QuestionOption> => {
+    try {
+      const { data } = await apolloClient.mutate<UpdateQuestionOptionResponse, UpdateQuestionOptionVariables>({
+        mutation: UPDATE_QUESTION_OPTION,
+        variables: { id: optionId, input },
+      })
+
+      if (!data?.updateQuestionOption) {
+        throw new Error('Missing updateQuestionOption response')
+      }
+
+      return mapOption(data.updateQuestionOption)
+    } catch (error) {
+      console.error('Failed to update question option via GraphQL:', error)
+      throw new Error('Failed to update question option')
+    }
+  },
+
+  deleteOption: async (optionId: string): Promise<void> => {
+    try {
+      await apolloClient.mutate<DeleteQuestionOptionResponse, DeleteQuestionOptionVariables>({
+        mutation: DELETE_QUESTION_OPTION,
+        variables: { id: optionId },
+      })
+    } catch (error) {
+      console.error('Failed to delete question option via GraphQL:', error)
+      throw new Error('Failed to delete question option')
+    }
   },
 }

--- a/lib/graphql/queries.ts
+++ b/lib/graphql/queries.ts
@@ -295,6 +295,188 @@ export const DELETE_MEDIA = gql`
   }
 `
 
+// Quiz queries and mutations
+export const GET_QUIZ = gql`
+  query GetQuiz($id: ID!) {
+    quiz(id: $id) {
+      id
+      lessonId
+      title
+      description
+      totalPoints
+      timeLimitS
+      createdAt
+      tags {
+        id
+        name
+      }
+      questions {
+        id
+        quizId
+        ord
+        type
+        prompt
+        promptMedia
+        points
+        metadata
+        options {
+          id
+          ord
+          label
+          isCorrect
+          feedback
+        }
+      }
+    }
+  }
+`
+
+export const GET_QUIZZES = gql`
+  query GetQuizzes(
+    $lessonId: ID
+    $search: String
+    $page: Int
+    $pageSize: Int
+    $orderBy: QuizOrderInput
+  ) {
+    quizzes(
+      lessonId: $lessonId
+      search: $search
+      page: $page
+      pageSize: $pageSize
+      orderBy: $orderBy
+    ) {
+      items {
+        id
+        lessonId
+        title
+        description
+        totalPoints
+        timeLimitS
+        createdAt
+        tags {
+          id
+          name
+        }
+      }
+      totalCount
+      page
+      pageSize
+    }
+  }
+`
+
+export const GET_QUIZ_QUESTIONS = gql`
+  query GetQuizQuestions(
+    $quizId: ID!
+    $filter: QuizQuestionFilterInput
+    $page: Int
+    $pageSize: Int
+    $orderBy: QuizQuestionOrderInput
+  ) {
+    quizQuestions(
+      quizId: $quizId
+      filter: $filter
+      page: $page
+      pageSize: $pageSize
+      orderBy: $orderBy
+    ) {
+      items {
+        id
+        quizId
+        ord
+        type
+        prompt
+        promptMedia
+        points
+        metadata
+        options {
+          id
+          ord
+          label
+          isCorrect
+          feedback
+        }
+      }
+      totalCount
+      page
+      pageSize
+    }
+  }
+`
+
+export const CREATE_QUIZ = gql`
+  mutation CreateQuiz($input: CreateQuizInput!) {
+    createQuiz(input: $input) {
+      id
+      lessonId
+      title
+      description
+      totalPoints
+      timeLimitS
+      createdAt
+      tags {
+        id
+        name
+      }
+    }
+  }
+`
+
+export const ADD_QUIZ_QUESTION = gql`
+  mutation AddQuizQuestion($quizId: ID!, $input: CreateQuizQuestionInput!) {
+    addQuizQuestion(quizId: $quizId, input: $input) {
+      id
+      quizId
+      ord
+      type
+      prompt
+      promptMedia
+      points
+      metadata
+      options {
+        id
+        ord
+        label
+        isCorrect
+        feedback
+      }
+    }
+  }
+`
+
+export const ADD_QUESTION_OPTION = gql`
+  mutation AddQuestionOption($questionId: ID!, $input: CreateQuestionOptionInput!) {
+    addQuestionOption(questionId: $questionId, input: $input) {
+      id
+      questionId
+      ord
+      label
+      isCorrect
+      feedback
+    }
+  }
+`
+
+export const UPDATE_QUESTION_OPTION = gql`
+  mutation UpdateQuestionOption($id: ID!, $input: UpdateQuestionOptionInput!) {
+    updateQuestionOption(id: $id, input: $input) {
+      id
+      questionId
+      ord
+      label
+      isCorrect
+      feedback
+    }
+  }
+`
+
+export const DELETE_QUESTION_OPTION = gql`
+  mutation DeleteQuestionOption($id: ID!) {
+    deleteQuestionOption(id: $id)
+  }
+`
+
 // Lesson queries and mutations
 export const GET_LESSON = gql`
   query GetLesson($id: ID!) {

--- a/types/quiz.ts
+++ b/types/quiz.ts
@@ -1,3 +1,5 @@
+import type { Tag } from "./common"
+
 export interface Quiz {
     id: string
     title: string
@@ -12,8 +14,11 @@ export interface Quiz {
     question_count?: number
     average_score?: number
     attempt_count?: number
+    total_points?: number
+    tags?: Tag[]
+    questions?: QuizQuestion[]
 
-    lesson_id: string // TODO: remove this after integration api 
+    lesson_id: string // TODO: remove this after integration api
     created_at: string
     updated_at: string
 }
@@ -26,6 +31,8 @@ export interface Question {
     points: number
     order: number
     prompt_media_id?: string
+    metadata?: Record<string, any>
+    options?: QuestionOption[]
 }
 
 export interface QuestionOption {
@@ -34,6 +41,7 @@ export interface QuestionOption {
     option_text: string
     is_correct: boolean
     order: number
+    feedback?: string
 }
 
 export interface QuizQuestion {
@@ -46,6 +54,8 @@ export interface QuizQuestion {
     explanation?: string
     correct_answer?: string
     answers?: QuizAnswer[]
+    prompt_media_id?: string
+    metadata?: Record<string, any>
 }
 
 export interface QuizAnswer {
@@ -54,6 +64,7 @@ export interface QuizAnswer {
     answer_text: string
     is_correct: boolean
     order: number
+    feedback?: string
 }
 
 // DTO types
@@ -67,6 +78,7 @@ export interface CreateQuizDto {
     shuffle_questions?: boolean
     shuffle_answers?: boolean
     show_correct_answers?: boolean
+    lesson_id?: string
 }
 
 export interface CreateQuestionDto {
@@ -75,6 +87,7 @@ export interface CreateQuestionDto {
     question_text: string
     points: number
     prompt_media_id?: string
+    metadata?: Record<string, any>
     options?: Array<{
         option_text: string
         is_correct: boolean


### PR DESCRIPTION
## Summary
- add quiz-related GraphQL queries and mutations to the shared query modules
- switch quiz and question API modules to consume the GraphQL endpoints and map the responses to existing UI types
- extend quiz type definitions with metadata such as tags, question payloads, and option feedback fields

## Testing
- pnpm lint *(fails: prompts for interactive ESLint setup in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e496873944832a82058e38e5d58eb2