### PR TITLE
Integrate lesson section API into lesson editor

### DIFF
--- a/components/lessons/lesson-editor-dialog.tsx
+++ b/components/lessons/lesson-editor-dialog.tsx
@@ -1,12 +1,14 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useState, useEffect, useCallback } from "react"
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { Button } from "@/components/ui/button"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { LessonSectionsEditor } from "./lesson-sections-editor"
 import type { Lesson, LessonSection } from "@/types/lesson"
-import { Eye, Save } from "lucide-react"
+import { Eye, Loader2, Save } from "lucide-react"
+import { api } from "@/lib/api/exports"
+import { useToast } from "@/hooks/use-toast"
 
 interface LessonEditorDialogProps {
   open: boolean
@@ -17,18 +19,68 @@ interface LessonEditorDialogProps {
 
 export function LessonEditorDialog({ open, onClose, lesson, onSave }: LessonEditorDialogProps) {
   const [sections, setSections] = useState<LessonSection[]>([])
+  const [initialSections, setInitialSections] = useState<LessonSection[]>([])
   const [activeTab, setActiveTab] = useState("edit")
+  const [isLoadingSections, setIsLoadingSections] = useState(false)
+  const [isSavingSections, setIsSavingSections] = useState(false)
+  const { toast } = useToast()
+
+  const loadSections = useCallback(
+    async (lessonId: string) => {
+      setIsLoadingSections(true)
+      try {
+        const data = await api.lessonSections.getByLessonId(lessonId)
+        setSections(data)
+        setInitialSections(data)
+      } catch (error) {
+        console.error("Failed to load lesson sections", error)
+        toast({
+          title: "Error",
+          description: error instanceof Error ? error.message : "Failed to load lesson sections",
+          variant: "destructive",
+        })
+        setSections([])
+        setInitialSections([])
+      } finally {
+        setIsLoadingSections(false)
+      }
+    },
+    [toast],
+  )
 
   useEffect(() => {
-    if (lesson) {
-      // In real app, would load sections from API
+    if (!open) {
       setSections([])
+      setInitialSections([])
+      setActiveTab("edit")
+      return
     }
-  }, [lesson])
 
-  const handleSave = () => {
-    onSave(sections)
-    onClose()
+    if (lesson) {
+      loadSections(lesson.id)
+    }
+  }, [lesson, loadSections, open])
+
+  const handleSave = async () => {
+    if (!lesson) return
+
+    setIsSavingSections(true)
+    try {
+      const updated = await api.lessonSections.sync(lesson.id, sections, initialSections)
+      setSections(updated)
+      setInitialSections(updated)
+      onSave(updated)
+      onClose()
+    } catch (error) {
+      console.error("Failed to save lesson sections", error)
+      toast({
+        title: "Error",
+        description: error instanceof Error ? error.message : "Failed to save lesson sections",
+        variant: "destructive",
+      })
+    } finally {
+      setIsSavingSections(false)
+    }
   }
 
   if (!lesson) return null
@@ -40,13 +92,17 @@ export function LessonEditorDialog({ open, onClose, lesson, onSave }: LessonEdit
           <div className="flex items-center justify-between">
             <DialogTitle>{lesson.title}</DialogTitle>
             <div className="flex gap-2">
-              <Button variant="outline" onClick={() => setActiveTab(activeTab === "edit" ? "preview" : "edit")}>
+              <Button variant="outline" onClick={() => setActiveTab(activeTab === "edit" ? "preview" : "edit")}> 
                 <Eye className="h-4 w-4 mr-2" />
                 {activeTab === "edit" ? "Preview" : "Edit"}
               </Button>
-              <Button onClick={handleSave}>
-                <Save className="h-4 w-4 mr-2" />
-                Save Changes
+              <Button onClick={handleSave} disabled={isSavingSections || isLoadingSections}>
+                {isSavingSections ? (
+                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                ) : (
+                  <Save className="h-4 w-4 mr-2" />
+                )}
+                {isSavingSections ? "Saving..." : "Save Changes"}
               </Button>
             </div>
           </div>
@@ -59,7 +115,13 @@ export function LessonEditorDialog({ open, onClose, lesson, onSave }: LessonEdit
           </TabsList>
 
           <TabsContent value="edit" className="flex-1 overflow-y-auto mt-4">
-            <LessonSectionsEditor lessonId={lesson.id} sections={sections} onSectionsChange={setSections} />
+            <LessonSectionsEditor
+              lessonId={lesson.id}
+              sections={sections}
+              onSectionsChange={setSections}
+              isLoading={isLoadingSections}
+              disabled={isSavingSections}
+            />
           </TabsContent>
 
           <TabsContent value="preview" className="flex-1 overflow-y-auto mt-4">

--- a/components/lessons/lesson-sections-editor.tsx
+++ b/components/lessons/lesson-sections-editor.tsx
@@ -13,12 +13,23 @@ interface LessonSectionsEditorProps {
   lessonId: string
   sections: LessonSection[]
   onSectionsChange: (sections: LessonSection[]) => void
+  isLoading?: boolean
+  disabled?: boolean
 }
 
-export function LessonSectionsEditor({ lessonId, sections, onSectionsChange }: LessonSectionsEditorProps) {
+export function LessonSectionsEditor({
+  lessonId,
+  sections,
+  onSectionsChange,
+  isLoading = false,
+  disabled = false,
+}: LessonSectionsEditorProps) {
   const [editingSection, setEditingSection] = useState<string | null>(null)
 
+  const isReadOnly = disabled || isLoading
+
   const addSection = (type: LessonSection["type"]) => {
+    if (isReadOnly) return
     const newSection: LessonSection = {
       id: `temp-${Date.now()}`,
       lesson_id: lessonId,
@@ -31,14 +42,17 @@ export function LessonSectionsEditor({ lessonId, sections, onSectionsChange }: L
   }
 
   const updateSection = (id: string, updates: Partial<LessonSection>) => {
+    if (isReadOnly) return
     onSectionsChange(sections.map((s) => (s.id === id ? { ...s, ...updates } : s)))
   }
 
   const deleteSection = (id: string) => {
+    if (isReadOnly) return
     onSectionsChange(sections.filter((s) => s.id !== id).map((s, index) => ({ ...s, order: index + 1 })))
   }
 
   const moveSection = (id: string, direction: "up" | "down") => {
+    if (isReadOnly) return
     const index = sections.findIndex((s) => s.id === id)
     if ((direction === "up" && index === 0) || (direction === "down" && index === sections.length - 1)) return
 
@@ -80,26 +94,30 @@ export function LessonSectionsEditor({ lessonId, sections, onSectionsChange }: L
       <div className="flex items-center justify-between">
         <h3 className="text-lg font-semibold">Lesson Sections</h3>
         <div className="flex gap-2">
-          <Button variant="outline" size="sm" onClick={() => addSection("text")}>
+          <Button variant="outline" size="sm" onClick={() => addSection("text")} disabled={isReadOnly}>
             <FileText className="h-4 w-4 mr-2" />
             Text
           </Button>
-          <Button variant="outline" size="sm" onClick={() => addSection("video")}>
+          <Button variant="outline" size="sm" onClick={() => addSection("video")} disabled={isReadOnly}>
             <Video className="h-4 w-4 mr-2" />
             Video
           </Button>
-          <Button variant="outline" size="sm" onClick={() => addSection("image")}>
+          <Button variant="outline" size="sm" onClick={() => addSection("image")} disabled={isReadOnly}>
             <ImageIcon className="h-4 w-4 mr-2" />
             Image
           </Button>
-          <Button variant="outline" size="sm" onClick={() => addSection("quiz")}>
+          <Button variant="outline" size="sm" onClick={() => addSection("quiz")} disabled={isReadOnly}>
             <HelpCircle className="h-4 w-4 mr-2" />
             Quiz
           </Button>
         </div>
       </div>
 
-      {sections.length === 0 ? (
+      {isLoading ? (
+        <Card className="p-12 text-center text-muted-foreground">
+          <p>Loading sections...</p>
+        </Card>
+      ) : sections.length === 0 ? (
         <Card className="p-12 text-center text-muted-foreground">
           <p>No sections yet. Add your first section to get started.</p>
         </Card>
@@ -118,7 +136,7 @@ export function LessonSectionsEditor({ lessonId, sections, onSectionsChange }: L
                       size="icon"
                       className="h-6 w-6 cursor-move"
                       onClick={() => moveSection(section.id, "up")}
-                      disabled={index === 0}
+                      disabled={index === 0 || isReadOnly}
                     >
                       <GripVertical className="h-4 w-4" />
                     </Button>
@@ -137,6 +155,7 @@ export function LessonSectionsEditor({ lessonId, sections, onSectionsChange }: L
                           variant="ghost"
                           size="sm"
                           onClick={() => setEditingSection(isEditing ? null : section.id)}
+                          disabled={isReadOnly}
                         >
                           {isEditing ? "Done" : "Edit"}
                         </Button>
@@ -145,6 +164,7 @@ export function LessonSectionsEditor({ lessonId, sections, onSectionsChange }: L
                           size="icon"
                           className="h-8 w-8"
                           onClick={() => deleteSection(section.id)}
+                          disabled={isReadOnly}
                         >
                           <Trash2 className="h-4 w-4 text-destructive" />
                         </Button>
@@ -159,6 +179,7 @@ export function LessonSectionsEditor({ lessonId, sections, onSectionsChange }: L
                             <Textarea
                               value={section.content || ""}
                               onChange={(e) => updateSection(section.id, { content: e.target.value })}
+                              disabled={isReadOnly}
                               placeholder="Enter text content..."
                               rows={6}
                             />
@@ -171,6 +192,7 @@ export function LessonSectionsEditor({ lessonId, sections, onSectionsChange }: L
                             <Textarea
                               value={section.content || ""}
                               onChange={(e) => updateSection(section.id, { content: e.target.value })}
+                              disabled={isReadOnly}
                               placeholder="Enter video URL or embed code..."
                               rows={3}
                             />
@@ -183,6 +205,7 @@ export function LessonSectionsEditor({ lessonId, sections, onSectionsChange }: L
                             <Select
                               value={section.media_id || ""}
                               onValueChange={(value) => updateSection(section.id, { media_id: value })}
+                              disabled={isReadOnly}
                             >
                               <SelectTrigger>
                                 <SelectValue placeholder="Select image from media library" />
@@ -201,6 +224,7 @@ export function LessonSectionsEditor({ lessonId, sections, onSectionsChange }: L
                             <Select
                               value={section.quiz_id || ""}
                               onValueChange={(value) => updateSection(section.id, { quiz_id: value })}
+                              disabled={isReadOnly}
                             >
                               <SelectTrigger>
                                 <SelectValue placeholder="Select quiz" />

--- a/lib/api/exports.ts
+++ b/lib/api/exports.ts
@@ -2,6 +2,7 @@ import { users } from './modules/users'
 import { media } from './modules/media'
 import { topics, levels, tags } from './modules/content'
 import { lessons } from './modules/lessons'
+import { lessonSections } from './modules/lesson-sections'
 import { quizzes } from './modules/quizzes'
 import { questions } from './modules/questions'
 import { enrollments } from './modules/enrollments'
@@ -19,6 +20,7 @@ export const api = {
   levels,
   tags,
   lessons,
+  lessonSections,
   quizzes,
   questions,
   enrollments,

--- a/lib/api/modules/lesson-sections.ts
+++ b/lib/api/modules/lesson-sections.ts
@@ -1,0 +1,261 @@
+import type { LessonSection } from '@/types/lesson'
+import { apolloClient } from '@/lib/graphql/client'
+import {
+  CREATE_LESSON_SECTION,
+  DELETE_LESSON_SECTION,
+  GET_LESSON_SECTIONS,
+  UPDATE_LESSON_SECTION,
+} from '@/lib/graphql/queries'
+import {
+  CreateLessonSectionInput,
+  CreateLessonSectionResponse,
+  CreateLessonSectionVariables,
+  DeleteLessonSectionResponse,
+  DeleteLessonSectionVariables,
+  GetLessonSectionsVariables,
+  LessonSection as GraphqlLessonSection,
+  LessonSectionsResponse,
+  LessonSectionType,
+  LessonSectionOrderField,
+  OrderDirection,
+  UpdateLessonSectionInput,
+  UpdateLessonSectionResponse,
+  UpdateLessonSectionVariables,
+} from '@/content_schema'
+
+type LessonSectionTypeKey = LessonSection['type']
+
+const UI_TO_GRAPHQL_SECTION_TYPE: Record<LessonSectionTypeKey, LessonSectionType> = {
+  text: LessonSectionType.TEXT,
+  video: LessonSectionType.DIALOG,
+  image: LessonSectionType.IMAGE,
+  quiz: LessonSectionType.EXERCISE,
+}
+
+const GRAPHQL_TO_UI_SECTION_TYPE: Record<LessonSectionType, LessonSectionTypeKey> = {
+  [LessonSectionType.TEXT]: 'text',
+  [LessonSectionType.DIALOG]: 'video',
+  [LessonSectionType.AUDIO]: 'video',
+  [LessonSectionType.IMAGE]: 'image',
+  [LessonSectionType.EXERCISE]: 'quiz',
+}
+
+const mapSectionBodyToUi = (section: GraphqlLessonSection): Partial<LessonSection> => {
+  const body = section.body ?? {}
+  const result: Partial<LessonSection> = {}
+
+  if (typeof body.content === 'string' && body.content.trim()) {
+    result.content = body.content
+  } else if (typeof body.text === 'string' && body.text.trim()) {
+    result.content = body.text
+  } else if (typeof body.embed === 'string' && body.embed.trim()) {
+    result.content = body.embed
+  } else if (typeof body.url === 'string' && body.url.trim()) {
+    result.content = body.url
+  }
+
+  if (typeof body.mediaId === 'string' && body.mediaId.trim()) {
+    result.media_id = body.mediaId
+  } else if (typeof body.imageId === 'string' && body.imageId.trim()) {
+    result.media_id = body.imageId
+  }
+
+  if (typeof body.quizId === 'string' && body.quizId.trim()) {
+    result.quiz_id = body.quizId
+  }
+
+  return result
+}
+
+const mapSectionBodyToGraphql = (section: LessonSection): CreateLessonSectionInput['body'] => {
+  const body: Record<string, any> = {}
+
+  const trimmedContent = section.content?.trim()
+
+  if (section.type === 'text' || section.type === 'video') {
+    if (trimmedContent) {
+      body.content = trimmedContent
+    }
+  }
+
+  if (section.type === 'image' && section.media_id) {
+    body.mediaId = section.media_id
+  }
+
+  if (section.type === 'quiz' && section.quiz_id) {
+    body.quizId = section.quiz_id
+  }
+
+  return body
+}
+
+const mapLessonSection = (section: GraphqlLessonSection): LessonSection => ({
+  id: section.id,
+  lesson_id: section.lessonId,
+  order: section.ord,
+  type: GRAPHQL_TO_UI_SECTION_TYPE[section.type] ?? 'text',
+  ...mapSectionBodyToUi(section),
+})
+
+const buildCreateInput = (section: LessonSection): CreateLessonSectionInput & { ord?: number } => {
+  const input: CreateLessonSectionInput & { ord?: number } = {
+    type: UI_TO_GRAPHQL_SECTION_TYPE[section.type] ?? LessonSectionType.TEXT,
+    body: mapSectionBodyToGraphql(section),
+  }
+
+  if (typeof section.order === 'number') {
+    input.ord = section.order
+  }
+
+  return input
+}
+
+const buildUpdateInput = (section: LessonSection): UpdateLessonSectionInput & { ord?: number } => {
+  const input: UpdateLessonSectionInput & { ord?: number } = {
+    type: UI_TO_GRAPHQL_SECTION_TYPE[section.type] ?? LessonSectionType.TEXT,
+    body: mapSectionBodyToGraphql(section),
+  }
+
+  if (typeof section.order === 'number') {
+    input.ord = section.order
+  }
+
+  return input
+}
+
+const isTemporaryId = (id: string) => id.startsWith('temp-')
+
+export const lessonSections = {
+  getByLessonId: async (lessonId: string): Promise<LessonSection[]> => {
+    try {
+      const variables: GetLessonSectionsVariables = {
+        lessonId,
+        page: 1,
+        pageSize: 100,
+        orderBy: {
+          field: LessonSectionOrderField.ORD,
+          direction: OrderDirection.ASC,
+        },
+      }
+
+      const { data } = await apolloClient.query<LessonSectionsResponse, GetLessonSectionsVariables>({
+        query: GET_LESSON_SECTIONS,
+        variables,
+        fetchPolicy: 'network-only',
+      })
+
+      if (!data?.lessonSections?.items) {
+        return []
+      }
+
+      return data.lessonSections.items.map(mapLessonSection)
+    } catch (error) {
+      console.error('Failed to fetch lesson sections from GraphQL:', error)
+      throw new Error('Failed to load lesson sections')
+    }
+  },
+
+  create: async (lessonId: string, section: LessonSection): Promise<LessonSection> => {
+    try {
+      const input = buildCreateInput(section)
+      const { data } = await apolloClient.mutate<CreateLessonSectionResponse, CreateLessonSectionVariables>({
+        mutation: CREATE_LESSON_SECTION,
+        variables: {
+          lessonId,
+          input,
+        },
+      })
+
+      if (!data?.createLessonSection) {
+        throw new Error('Failed to create lesson section')
+      }
+
+      return mapLessonSection(data.createLessonSection)
+    } catch (error) {
+      console.error('Failed to create lesson section via GraphQL:', error)
+      throw new Error('Failed to create lesson section')
+    }
+  },
+
+  update: async (section: LessonSection): Promise<LessonSection> => {
+    if (isTemporaryId(section.id)) {
+      throw new Error('Cannot update a section that has not been saved yet')
+    }
+
+    try {
+      const input = buildUpdateInput(section)
+      const { data } = await apolloClient.mutate<UpdateLessonSectionResponse, UpdateLessonSectionVariables>({
+        mutation: UPDATE_LESSON_SECTION,
+        variables: {
+          id: section.id,
+          input,
+        },
+      })
+
+      if (!data?.updateLessonSection) {
+        throw new Error('Failed to update lesson section')
+      }
+
+      return mapLessonSection(data.updateLessonSection)
+    } catch (error) {
+      console.error('Failed to update lesson section via GraphQL:', error)
+      throw new Error('Failed to update lesson section')
+    }
+  },
+
+  delete: async (id: string): Promise<void> => {
+    if (isTemporaryId(id)) {
+      return
+    }
+
+    try {
+      const { data } = await apolloClient.mutate<DeleteLessonSectionResponse, DeleteLessonSectionVariables>({
+        mutation: DELETE_LESSON_SECTION,
+        variables: { id },
+      })
+
+      if (!data?.deleteLessonSection) {
+        throw new Error('Failed to delete lesson section')
+      }
+    } catch (error) {
+      console.error('Failed to delete lesson section via GraphQL:', error)
+      throw new Error('Failed to delete lesson section')
+    }
+  },
+
+  sync: async (
+    lessonId: string,
+    updatedSections: LessonSection[],
+    originalSections: LessonSection[],
+  ): Promise<LessonSection[]> => {
+    const originalById = new Map(originalSections.map((section) => [section.id, section]))
+    const updatedById = new Map(updatedSections.map((section) => [section.id, section]))
+
+    const deletionPromises = originalSections
+      .filter((section) => !updatedById.has(section.id))
+      .map((section) => lessonSections.delete(section.id))
+
+    await Promise.all(deletionPromises)
+
+    for (const section of updatedSections) {
+      if (isTemporaryId(section.id)) {
+        await lessonSections.create(lessonId, section)
+      } else {
+        const original = originalById.get(section.id)
+        const hasChanged =
+          !original ||
+          original.type !== section.type ||
+          original.content !== section.content ||
+          original.media_id !== section.media_id ||
+          original.quiz_id !== section.quiz_id ||
+          original.order !== section.order
+
+        if (hasChanged) {
+          await lessonSections.update(section)
+        }
+      }
+    }
+
+    return await lessonSections.getByLessonId(lessonId)
+  },
+}

--- a/lib/graphql/queries.ts
+++ b/lib/graphql/queries.ts
@@ -492,3 +492,65 @@ export const DELETE_LESSON = gql`
     deleteLesson(id: $id)
   }
 `
+
+export const GET_LESSON_SECTIONS = gql`
+  query GetLessonSections(
+    $lessonId: ID!
+    $filter: LessonSectionFilterInput
+    $page: Int
+    $pageSize: Int
+    $orderBy: LessonSectionOrderInput
+  ) {
+    lessonSections(
+      lessonId: $lessonId
+      filter: $filter
+      page: $page
+      pageSize: $pageSize
+      orderBy: $orderBy
+    ) {
+      items {
+        id
+        lessonId
+        ord
+        type
+        body
+        createdAt
+      }
+      totalCount
+      page
+      pageSize
+    }
+  }
+`
+
+export const CREATE_LESSON_SECTION = gql`
+  mutation CreateLessonSection($lessonId: ID!, $input: CreateLessonSectionInput!) {
+    createLessonSection(lessonId: $lessonId, input: $input) {
+      id
+      lessonId
+      ord
+      type
+      body
+      createdAt
+    }
+  }
+`
+
+export const UPDATE_LESSON_SECTION = gql`
+  mutation UpdateLessonSection($id: ID!, $input: UpdateLessonSectionInput!) {
+    updateLessonSection(id: $id, input: $input) {
+      id
+      lessonId
+      ord
+      type
+      body
+      createdAt
+    }
+  }
+`
+
+export const DELETE_LESSON_SECTION = gql`
+  mutation DeleteLessonSection($id: ID!) {
+    deleteLessonSection(id: $id)
+  }
+`


### PR DESCRIPTION
## Summary
- add a dedicated lessonSections API module with GraphQL queries for listing, creating, updating, and deleting lesson sections
- load and persist lesson sections in the lesson editor dialog while surfacing loading and saving states
- update the lesson sections editor UI to support disabled/loading interactions when data is being fetched or saved

## Testing
- pnpm lint *(fails: prompts for interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_b_68e498cdcf54832a8c3295b1dc3e7a86