### PR TITLE
Integrate API search for quizzes page

### DIFF
--- a/lib/api/modules/quizzes.ts
+++ b/lib/api/modules/quizzes.ts
@@ -151,12 +151,23 @@ const buildCreateQuizInput = (data: CreateQuizDto): CreateQuizVariables['input']
   timeLimitS: data.time_limit ? data.time_limit * 60 : undefined,
 })
 
+type GetAllQuizzesParams = {
+  search?: string
+}
+
 export const quizzes = {
-  getAll: async (): Promise<Quiz[]> => {
+  getAll: async (params: GetAllQuizzesParams = {}): Promise<Quiz[]> => {
     try {
+      const search = params.search?.trim()
+      const variables: GetQuizzesVariables = { page: 1, pageSize: 50 }
+
+      if (search) {
+        variables.search = search
+      }
+
       const { data } = await apolloClient.query<QuizzesResponse, GetQuizzesVariables>({
         query: GET_QUIZZES,
-        variables: { page: 1, pageSize: 50 },
+        variables,
         fetchPolicy: 'network-only',
       })
 


### PR DESCRIPTION
## Summary
- fetch quizzes through the API search endpoint when the search query changes
- keep topic and level filtering client-side while reusing the new server-filtered results
- allow the quizzes API module to accept an optional search parameter when querying GraphQL

## Testing
- pnpm lint *(fails: interactive Next.js ESLint setup prompt)*

------
https://chatgpt.com/codex/tasks/task_b_68e5e1e2a9f4832aba0ee06ab146e1cd